### PR TITLE
Fix a double-free() issue in discuss server

### DIFF
--- a/server/coreutil.c
+++ b/server/coreutil.c
@@ -139,6 +139,7 @@ char *mtg_name;
 	  (void) close (u_control_f);
 	  current_mtg [0] = '\0';
 	  acl_destroy(mtg_acl);
+	  mtg_acl = NULL;
      }
 
      u_trn_f = u_control_f = u_acl_f = 0;


### PR DESCRIPTION
In case when the client tried to switch from an existing meeting to
a non-existing one, the client freed the memory from the previous
meeting, but forgot to null the pointer, which caused the error handler
to attempt to free it again upon discovering that meeting did not exist
and cause the server to crash.
